### PR TITLE
Add accessibility ramp case study with corrected concrete volume

### DIFF
--- a/en/case-studies.html
+++ b/en/case-studies.html
@@ -88,6 +88,14 @@
                     <p class="mt-2 text-slate-600"><span class="font-semibold">Result:</span> Bought the precise number of bags needed, avoiding extra trips to the store and leftover materials.</p>
                 </div>
             </div>
+            <div class="bg-white rounded-lg shadow-lg overflow-hidden">
+                <div class="p-6">
+                    <h2 class="text-2xl font-bold text-slate-900">Community Center Accessibility Ramp</h2>
+                    <p class="mt-2 text-slate-600"><span class="font-semibold">Challenge:</span> Volunteers needed to pour a 432 square foot ramp with an average thickness of 4.8 inches (0.4 ft) but were unsure how much ready-mix to schedule.</p>
+                    <p class="mt-2 text-slate-600"><span class="font-semibold">Solution:</span> Used the <a href="/en/slab-calculator.html" class="text-brand-secondary">Slab Calculator</a> to enter the ramp dimensions, which returned 172.8 cubic feet (6.40 cubic yards) of concrete. They rounded up to a 7 cubic yard delivery to allow for waste and finishing.</p>
+                    <p class="mt-2 text-slate-600"><span class="font-semibold">Result:</span> Instead of guessing and ordering 10 cubic yards, they confidently booked 7 cubic yards and avoided paying for three unnecessary yards—about $420 in savings at $140 per yard.</p>
+                </div>
+            </div>
         </div>
 
         <div class="mt-16 pt-8 border-t border-slate-200 text-center">

--- a/zh/case-studies.html
+++ b/zh/case-studies.html
@@ -88,6 +88,14 @@
                     <p class="mt-2 text-slate-600"><span class="font-semibold">结果:</span> 购买了所需的确切袋数，避免了额外去商店的麻烦和材料的浪费。</p>
                 </div>
             </div>
+            <div class="bg-white rounded-lg shadow-lg overflow-hidden">
+                <div class="p-6">
+                    <h2 class="text-2xl font-bold text-slate-900">社区无障碍坡道改造</h2>
+                    <p class="mt-2 text-slate-600"><span class="font-semibold">挑战:</span> 志愿团队需要浇筑一条432平方英尺、平均厚度4.8英寸（0.4英尺）的无障碍坡道，却拿不准应订购多少商品混凝土。</p>
+                    <p class="mt-2 text-slate-600"><span class="font-semibold">解决方案:</span> 使用<a href="/zh/slab-calculator.html" class="text-brand-secondary">板计算器</a>输入坡道尺寸，计算得出需要172.8立方英尺（6.40立方码）的混凝土，并上调到7立方码的配送量以预留损耗和收面空间。</p>
+                    <p class="mt-2 text-slate-600"><span class="font-semibold">结果:</span> 他们不再凭感觉订10立方码，而是安心预订7立方码，避免额外支付3立方码的费用——按每立方码140美元计算，大约节省了420美元。</p>
+                </div>
+            </div>
         </div>
 
         <div class="mt-16 pt-8 border-t border-slate-200 text-center">


### PR DESCRIPTION
## Summary
- add a community accessibility ramp case study to the English and Chinese pages
- correct the ramp's concrete volume to 172.8 cubic feet (6.40 cubic yards) and align the delivery and savings narrative

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68dca70d939483338c2d21285d8da2ce