### PR TITLE
Update case study bag quantities for 12x16 patio project

### DIFF
--- a/en/case-studies.html
+++ b/en/case-studies.html
@@ -68,7 +68,7 @@
                 <div class="p-6">
                     <h2 class="text-2xl font-bold text-slate-900">John's Patio Project</h2>
                     <p class="mt-2 text-slate-600"><span class="font-semibold">Challenge:</span> Accurately estimate the concrete needed for a 12x16 foot backyard patio.</p>
-                    <p class="mt-2 text-slate-600"><span class="font-semibold">Solution:</span> Used the <a href="/en/slab-calculator.html" class="text-brand-secondary">Slab Calculator</a> to determine the exact volume. The material breakdown helped him purchase the right amount of cement, sand, and gravel.</p>
+                    <p class="mt-2 text-slate-600"><span class="font-semibold">Solution:</span> Used the <a href="/en/slab-calculator.html" class="text-brand-secondary">Slab Calculator</a> to determine the exact volume. The material breakdown helped him purchase the right amount of cement, sand, and gravel, including 107 × 80 lb bags (110 with waste) to match the 12×16×0.33 ft slab's ~64 ft³ volume.</p>
                     <p class="mt-2 text-slate-600"><span class="font-semibold">Result:</span> Saved over $150 by avoiding over-ordering and finished the project on budget.</p>
                 </div>
             </div>

--- a/zh/case-studies.html
+++ b/zh/case-studies.html
@@ -68,7 +68,7 @@
                 <div class="p-6">
                     <h2 class="text-2xl font-bold text-slate-900">张伟的庭院项目</h2>
                     <p class="mt-2 text-slate-600"><span class="font-semibold">挑战:</span> 精确估算一个12x16英尺后院庭院所需的混凝土。</p>
-                    <p class="mt-2 text-slate-600"><span class="font-semibold">解决方案:</span> 使用<a href="/zh/slab-calculator.html" class="text-brand-secondary">板计算器</a>确定确切的体积。材料明细帮助他购买了适量的水泥、沙子和砾石。</p>
+                    <p class="mt-2 text-slate-600"><span class="font-semibold">解决方案:</span> 使用<a href="/zh/slab-calculator.html" class="text-brand-secondary">板计算器</a>确定确切的体积。材料明细帮助他购买了适量的水泥、沙子和砾石，包括与12×16×0.33英尺板约64立方英尺体积相匹配的107袋80磅袋装料（含损耗共110袋）。</p>
                     <p class="mt-2 text-slate-600"><span class="font-semibold">结果:</span> 通过避免超额订购，节省了超过1000元人民币，并按预算完成了项目。</p>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- update the English and Chinese case study descriptions to cite 107 × 80 lb bags (110 with waste) for the 12×16×0.33 ft slab
- clarify that the bag counts align with the slab's ~64 ft³ volume in both languages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dca7653d1c8333b377ad2e0032f594